### PR TITLE
Add support for no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,6 @@ repository = "https://github.com/dfrg/yazi"
 homepage = "https://github.com/dfrg/yazi"
 readme = "README.md"
 
-[dependencies]
+[features]
+default = ["std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,9 +230,14 @@
 //! decompressor is based on the techniques in libdeflate (<https://github.com/ebiggers/libdeflate>)
 //! by Eric Biggers.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 mod decode;
 mod encode;
 
+#[cfg(feature = "std")]
 use std::io;
 
 pub use decode::{decompress, Decoder, DecoderStream};
@@ -259,9 +264,13 @@ pub enum Error {
     /// Attempt to write into a finished stream.
     Finished,
     /// A system I/O error.
+    /// 
+    /// Only available with the `std` feature enabled.
+    #[cfg(feature = "std")]
     Io(io::Error),
 }
 
+#[cfg(feature = "std")]
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
         Self::Io(error)
@@ -315,6 +324,7 @@ impl Default for Adler32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     fn generate_bytes() -> Vec<u8> {
         const BYTES: &[u8; 26] = b"abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
This commit adds a default "std" feature that can be disabled to run this crate in no_std environments. This allows for Zlib compression or decompression to happen on embedded systems.

Rel: https://github.com/dfrg/swash/issues/4

This is a breaking change, as anyone who is already importing yazi with "default-features = false" and using the From<io::Error> impl on yazi::Error will have their build break after this commit.